### PR TITLE
Use text for source & example links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var projection = d3.geoEquirectangular()
 
 ## API Reference
 
-<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@mbostock/spherical-clipping "Explore on Observable")
+<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) [examples](https://observablehq.com/@mbostock/spherical-clipping)
 
 Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable for [_projection_.preclip](https://github.com/d3/d3-geo#preclip).
 
@@ -39,7 +39,7 @@ Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable fo
 Given a clipPolygon function, returns the GeoJSON polygon.
 
 
-<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@fil/spherical-intersection "Explore on Observable")
+<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) [examples](https://observablehq.com/@fil/spherical-intersection)
 
 
 Given two spherical arcs [point0, point1] and [point2, point3], returns their intersection, or undefined if there is none. See “[Spherical Intersection](https://observablehq.com/@fil/spherical-intersection)”.
@@ -50,7 +50,7 @@ Given two spherical arcs [point0, point1] and [point2, point3], returns their in
 d3-geo-polygon adds polygon clipping to the polyhedral projections from [d3-geo-projection](https://github.com/d3/d3-geo-projection). Thus, it supercedes the following symbols:
 
 
-<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon "Explore on Observable")
+<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) [examples](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
 
 
 Defines a new polyhedral projection. The *tree* is a spanning tree of polygon face nodes; each *node* is assigned a *node*.transform matrix. The *face* function returns the appropriate *node* for a given *lambda* and *phi* in radians.
@@ -58,19 +58,19 @@ Defines a new polyhedral projection. The *tree* is a spanning tree of polygon fa
 <a href="#geoPolyhedral_tree" name="geoPolyhedral_tree">#</a> <i>polyhedral</i>.<b>tree</b>() returns the spanning tree of the polyhedron, from which one can infer the faces’ centers, polygons, shared edges etc.
 
 
-<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js "Source")
+<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralButterfly.png" width="480" height="250">](https://observablehq.com/@d3/polyhedral-gnomonic)
 
 The gnomonic butterfly projection.
 
-<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js "Source")
+<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralCollignon.png" width="480" height="250">](https://www.jasondavies.com/maps/collignon-butterfly/)
 
 The Collignon butterfly projection.
 
-<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js "Source")
+<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralWaterman.png" width="480" height="250">](https://www.jasondavies.com/maps/waterman-butterfly/)
 
@@ -79,47 +79,47 @@ A butterfly projection inspired by Steve Waterman’s design.
 
 New projections are introduced:
 
-<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js "Source")
+<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)
 
 Returns a polyhedral projection based on the *polygons*, arranged in a tree according to the *parents* list. *polygons* are a GeoJSON FeatureCollection of geoVoronoi cells, which should indicate the corresponding sites (see [d3-geo-voronoi](https://github.com/Fil/d3-geo-voronoi)). An optional [*faceProjection*](#geoPolyhedral) is passed to d3.geoPolyhedral() -- note that the gnomonic projection on the polygons’ sites is the only faceProjection that works in the general case.
 
 The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>faceProjection</b>([<i>faceProjection</i>]) set and read the corresponding options. Use <i>.faceFind(voronoi.find)</i> for faster results.
 
-<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@fil/cubic-projections "Explore on Observable")
+<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) [examples](https://observablehq.com/@fil/cubic-projections)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cubic.png" width="480" height="250">](https://observablehq.com/@fil/cubic-projections)
 
 The cubic projection.
 
-<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@fil/dodecahedral-projection "Explore on Observable")
+<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) [examples](https://observablehq.com/@fil/dodecahedral-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/dodecahedral.png" width="480" height="250">](https://observablehq.com/@fil/dodecahedral-projection)
 
 The dodecahedral projection.
 
-<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@fil/icosahedral-projections "Explore on Observable")
+<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) [examples](https://observablehq.com/@fil/icosahedral-projections)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/icosahedral.png" width="480" height="250">](https://observablehq.com/@fil/icosahedral-projections)
 
 The icosahedral projection.
 
-<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@fil/airocean-projection "Explore on Observable")
+<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) [examples](https://observablehq.com/@fil/airocean-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/airocean.png" width="480" height="250">](https://observablehq.com/@fil/airocean-projection)
 
 Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based on a very specific arrangement of the icosahedron which allows continuous continent shapes. Fuller’s triangle transformation, as formulated by Robert W. Gray (and implemented by Philippe Rivière), makes the projection almost equal-area.
 
-<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@d3/cahill-keyes "Explore on Observable")
+<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) [examples](https://observablehq.com/@d3/cahill-keyes)
 <br><a href="#geoCahillKeyesRaw" name="geoCahillKeyesRaw">#</a> d3.<b>geoCahillKeyes</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cahillKeyes.png" width="480" height="250">](http://www.genekeyes.com/)
 
 The Cahill-Keyes projection, designed by Gene Keyes (1975), is built on Bernard J. S. Cahill’s 1909 octant design. Implementation by Mary Jo Graça (2011), ported to D3 by Enrico Spinielli (2013).
 
-<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@fil/the-imago-projection "Explore on Observable")
+<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) [examples](https://observablehq.com/@fil/the-imago-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/imago.png" width="480" height="250">](https://kunimune.home.blog/2017/11/23/the-secrets-of-the-authagraph-revealed/)
@@ -134,7 +134,7 @@ Exponent. Useful values include 0.59 (default, minimizes angular distortion of t
 
 Horizontal shift. Defaults to 1.16.
 
-<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@fil/lee-projection "Explore on Observable")
+<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) [examples](https://observablehq.com/@fil/lee-projection)
 <br><a href="#geoLeeRaw" name="geoLeeRaw">#</a> d3.<b>geoLeeRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/tetrahedralLee.png" width="480" height="250">](https://observablehq.com/@d3/lees-tetrahedral)
@@ -145,10 +145,9 @@ Lee’s tetrahedral conformal projection.
 
 Default aspect uses *projection*.rotate([30, 180]) and has the North Pole at the triangle’s center -- use *projection*.rotate([-30, 0]) for the [South aspect](https://observablehq.com/@fil/lee-projection).
 
-<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [![src](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/octicon-code.svg?sanitize=true)](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js "Source") [![observable](https://raw.githubusercontent.com/d3/d3-geo-polygon/links/img/observable-logo.svg?sanitize=true)](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle "Explore on Observable")
+<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) [examples](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
 <br><a href="#geoCoxRaw" name="geoCoxRaw">#</a> d3.<b>geoCoxRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cox.png" width="480" height="250">](https://visionscarto.net/cox-conformal-projection)
 
 The Cox conformal projection.
-

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ var projection = d3.geoEquirectangular()
 ## API Reference
 
 <a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>)
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) · [Examples]](https://observablehq.com/@mbostock/spherical-clipping)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) · [Examples](https://observablehq.com/@mbostock/spherical-clipping)
 
 Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable for [_projection_.preclip](https://github.com/d3/d3-geo#preclip).
 
@@ -41,7 +41,7 @@ Given a clipPolygon function, returns the GeoJSON polygon.
 
 
 <a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>)
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) · [Examples]](https://observablehq.com/@fil/spherical-intersection)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) · [Examples](https://observablehq.com/@fil/spherical-intersection)
 
 
 Given two spherical arcs [point0, point1] and [point2, point3], returns their intersection, or undefined if there is none. See “[Spherical Intersection](https://observablehq.com/@fil/spherical-intersection)”.
@@ -53,7 +53,7 @@ d3-geo-polygon adds polygon clipping to the polyhedral projections from [d3-geo-
 
 
 <a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>)
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) · [Examples]](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) · [Examples](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
 
 
 Defines a new polyhedral projection. The *tree* is a spanning tree of polygon face nodes; each *node* is assigned a *node*.transform matrix. The *face* function returns the appropriate *node* for a given *lambda* and *phi* in radians.
@@ -93,7 +93,7 @@ Returns a polyhedral projection based on the *polygons*, arranged in a tree acco
 The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>faceProjection</b>([<i>faceProjection</i>]) set and read the corresponding options. Use <i>.faceFind(voronoi.find)</i> for faster results.
 
 <a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) · [Examples]](https://observablehq.com/@fil/cubic-projections)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) · [Examples](https://observablehq.com/@fil/cubic-projections)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cubic.png" width="480" height="250">](https://observablehq.com/@fil/cubic-projections)
@@ -101,7 +101,7 @@ The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>
 The cubic projection.
 
 <a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) · [Examples]](https://observablehq.com/@fil/dodecahedral-projection)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) · [Examples](https://observablehq.com/@fil/dodecahedral-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/dodecahedral.png" width="480" height="250">](https://observablehq.com/@fil/dodecahedral-projection)
@@ -109,14 +109,14 @@ The cubic projection.
 The dodecahedral projection.
 
 <a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) · [Examples]](https://observablehq.com/@fil/icosahedral-projections)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) · [Examples](https://observablehq.com/@fil/icosahedral-projections)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/icosahedral.png" width="480" height="250">](https://observablehq.com/@fil/icosahedral-projections)
 
 The icosahedral projection.
 
 <a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) · [Examples]](https://observablehq.com/@fil/airocean-projection)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) · [Examples](https://observablehq.com/@fil/airocean-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/airocean.png" width="480" height="250">](https://observablehq.com/@fil/airocean-projection)
@@ -124,7 +124,7 @@ The icosahedral projection.
 Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based on a very specific arrangement of the icosahedron which allows continuous continent shapes. Fuller’s triangle transformation, as formulated by Robert W. Gray (and implemented by Philippe Rivière), makes the projection almost equal-area.
 
 <a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) · [Examples]](https://observablehq.com/@d3/cahill-keyes)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) · [Examples](https://observablehq.com/@d3/cahill-keyes)
 <br><a href="#geoCahillKeyesRaw" name="geoCahillKeyesRaw">#</a> d3.<b>geoCahillKeyes</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cahillKeyes.png" width="480" height="250">](http://www.genekeyes.com/)
@@ -132,7 +132,7 @@ Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based
 The Cahill-Keyes projection, designed by Gene Keyes (1975), is built on Bernard J. S. Cahill’s 1909 octant design. Implementation by Mary Jo Graça (2011), ported to D3 by Enrico Spinielli (2013).
 
 <a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) · [Examples]](https://observablehq.com/@fil/the-imago-projection)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) · [Examples](https://observablehq.com/@fil/the-imago-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/imago.png" width="480" height="250">](https://kunimune.home.blog/2017/11/23/the-secrets-of-the-authagraph-revealed/)
@@ -148,7 +148,7 @@ Exponent. Useful values include 0.59 (default, minimizes angular distortion of t
 Horizontal shift. Defaults to 1.16.
 
 <a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) · [Examples]](https://observablehq.com/@fil/lee-projection)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) · [Examples](https://observablehq.com/@fil/lee-projection)
 <br><a href="#geoLeeRaw" name="geoLeeRaw">#</a> d3.<b>geoLeeRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/tetrahedralLee.png" width="480" height="250">](https://observablehq.com/@d3/lees-tetrahedral)
@@ -160,7 +160,7 @@ Lee’s tetrahedral conformal projection.
 Default aspect uses *projection*.rotate([30, 180]) and has the North Pole at the triangle’s center -- use *projection*.rotate([-30, 0]) for the [South aspect](https://observablehq.com/@fil/lee-projection).
 
 <a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) · [Examples]](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) · [Examples](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
 <br><a href="#geoCoxRaw" name="geoCoxRaw">#</a> d3.<b>geoCoxRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cox.png" width="480" height="250">](https://visionscarto.net/cox-conformal-projection)

--- a/README.md
+++ b/README.md
@@ -29,111 +29,86 @@ var projection = d3.geoEquirectangular()
 
 ## API Reference
 
-<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>)
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) · [Examples](https://observablehq.com/@mbostock/spherical-clipping)
+<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) · [Examples](https://observablehq.com/@mbostock/spherical-clipping)
 
 Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable for [_projection_.preclip](https://github.com/d3/d3-geo#preclip).
-
 
 <a name="polygon" href="#polygon">#</a> clip.<b>polygon</b>()
 
 Given a clipPolygon function, returns the GeoJSON polygon.
 
-
-<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>)
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) · [Examples](https://observablehq.com/@fil/spherical-intersection)
-
+<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) · [Examples](https://observablehq.com/@fil/spherical-intersection)
 
 Given two spherical arcs [point0, point1] and [point2, point3], returns their intersection, or undefined if there is none. See “[Spherical Intersection](https://observablehq.com/@fil/spherical-intersection)”.
-
 
 ## Projections
 
 d3-geo-polygon adds polygon clipping to the polyhedral projections from [d3-geo-projection](https://github.com/d3/d3-geo-projection). Thus, it supercedes the following symbols:
 
-
-<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>)
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) · [Examples](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
-
+<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) · [Examples](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
 
 Defines a new polyhedral projection. The *tree* is a spanning tree of polygon face nodes; each *node* is assigned a *node*.transform matrix. The *face* function returns the appropriate *node* for a given *lambda* and *phi* in radians.
 
 <a href="#geoPolyhedral_tree" name="geoPolyhedral_tree">#</a> <i>polyhedral</i>.<b>tree</b>() returns the spanning tree of the polyhedron, from which one can infer the faces’ centers, polygons, shared edges etc.
 
-
-<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>()
-<br>[[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)]
+<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralButterfly.png" width="480" height="250">](https://observablehq.com/@d3/polyhedral-gnomonic)
 
 The gnomonic butterfly projection.
 
-<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>()
-<br>[[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)]
+<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralCollignon.png" width="480" height="250">](https://www.jasondavies.com/maps/collignon-butterfly/)
 
 The Collignon butterfly projection.
 
-<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>()
-<br>[[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)]
+<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralWaterman.png" width="480" height="250">](https://www.jasondavies.com/maps/waterman-butterfly/)
 
 A butterfly projection inspired by Steve Waterman’s design.
 
-
 New projections are introduced:
 
-<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>])
-<br>[[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)]
+<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)
 
 Returns a polyhedral projection based on the *polygons*, arranged in a tree according to the *parents* list. *polygons* are a GeoJSON FeatureCollection of geoVoronoi cells, which should indicate the corresponding sites (see [d3-geo-voronoi](https://github.com/Fil/d3-geo-voronoi)). An optional [*faceProjection*](#geoPolyhedral) is passed to d3.geoPolyhedral() -- note that the gnomonic projection on the polygons’ sites is the only faceProjection that works in the general case.
 
 The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>faceProjection</b>([<i>faceProjection</i>]) set and read the corresponding options. Use <i>.faceFind(voronoi.find)</i> for faster results.
 
-<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) · [Examples](https://observablehq.com/@fil/cubic-projections)
-
+<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) · [Examples](https://observablehq.com/@fil/cubic-projections)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cubic.png" width="480" height="250">](https://observablehq.com/@fil/cubic-projections)
 
 The cubic projection.
 
-<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) · [Examples](https://observablehq.com/@fil/dodecahedral-projection)
-
+<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) · [Examples](https://observablehq.com/@fil/dodecahedral-projection)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/dodecahedral.png" width="480" height="250">](https://observablehq.com/@fil/dodecahedral-projection)
 
 The dodecahedral projection.
 
-<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) · [Examples](https://observablehq.com/@fil/icosahedral-projections)
+<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) · [Examples](https://observablehq.com/@fil/icosahedral-projections)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/icosahedral.png" width="480" height="250">](https://observablehq.com/@fil/icosahedral-projections)
 
 The icosahedral projection.
 
-<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) · [Examples](https://observablehq.com/@fil/airocean-projection)
-
+<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) · [Examples](https://observablehq.com/@fil/airocean-projection)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/airocean.png" width="480" height="250">](https://observablehq.com/@fil/airocean-projection)
 
 Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based on a very specific arrangement of the icosahedron which allows continuous continent shapes. Fuller’s triangle transformation, as formulated by Robert W. Gray (and implemented by Philippe Rivière), makes the projection almost equal-area.
 
-<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) · [Examples](https://observablehq.com/@d3/cahill-keyes)
+<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) · [Examples](https://observablehq.com/@d3/cahill-keyes)
 <br><a href="#geoCahillKeyesRaw" name="geoCahillKeyesRaw">#</a> d3.<b>geoCahillKeyes</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cahillKeyes.png" width="480" height="250">](http://www.genekeyes.com/)
 
 The Cahill-Keyes projection, designed by Gene Keyes (1975), is built on Bernard J. S. Cahill’s 1909 octant design. Implementation by Mary Jo Graça (2011), ported to D3 by Enrico Spinielli (2013).
 
-<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) · [Examples](https://observablehq.com/@fil/the-imago-projection)
-
+<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) · [Examples](https://observablehq.com/@fil/the-imago-projection)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/imago.png" width="480" height="250">](https://kunimune.home.blog/2017/11/23/the-secrets-of-the-authagraph-revealed/)
 
@@ -147,8 +122,7 @@ Exponent. Useful values include 0.59 (default, minimizes angular distortion of t
 
 Horizontal shift. Defaults to 1.16.
 
-<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) · [Examples](https://observablehq.com/@fil/lee-projection)
+<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) · [Examples](https://observablehq.com/@fil/lee-projection)
 <br><a href="#geoLeeRaw" name="geoLeeRaw">#</a> d3.<b>geoLeeRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/tetrahedralLee.png" width="480" height="250">](https://observablehq.com/@d3/lees-tetrahedral)
@@ -159,8 +133,7 @@ Lee’s tetrahedral conformal projection.
 
 Default aspect uses *projection*.rotate([30, 180]) and has the North Pole at the triangle’s center -- use *projection*.rotate([-30, 0]) for the [South aspect](https://observablehq.com/@fil/lee-projection).
 
-<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>()
-<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) · [Examples](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
+<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) · [Examples](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
 <br><a href="#geoCoxRaw" name="geoCoxRaw">#</a> d3.<b>geoCoxRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cox.png" width="480" height="250">](https://visionscarto.net/cox-conformal-projection)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var projection = d3.geoEquirectangular()
 
 ## API Reference
 
-<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) · [Examples](https://observablehq.com/@mbostock/spherical-clipping)
+<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js), [Examples](https://observablehq.com/@mbostock/spherical-clipping)
 
 Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable for [_projection_.preclip](https://github.com/d3/d3-geo#preclip).
 
@@ -37,7 +37,7 @@ Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable fo
 
 Given a clipPolygon function, returns the GeoJSON polygon.
 
-<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) · [Examples](https://observablehq.com/@fil/spherical-intersection)
+<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js), [Examples](https://observablehq.com/@fil/spherical-intersection)
 
 Given two spherical arcs [point0, point1] and [point2, point3], returns their intersection, or undefined if there is none. See “[Spherical Intersection](https://observablehq.com/@fil/spherical-intersection)”.
 
@@ -45,7 +45,7 @@ Given two spherical arcs [point0, point1] and [point2, point3], returns their in
 
 d3-geo-polygon adds polygon clipping to the polyhedral projections from [d3-geo-projection](https://github.com/d3/d3-geo-projection). Thus, it supercedes the following symbols:
 
-<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) · [Examples](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
+<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js), [Examples](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
 
 Defines a new polyhedral projection. The *tree* is a spanning tree of polygon face nodes; each *node* is assigned a *node*.transform matrix. The *face* function returns the appropriate *node* for a given *lambda* and *phi* in radians.
 
@@ -77,38 +77,38 @@ Returns a polyhedral projection based on the *polygons*, arranged in a tree acco
 
 The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>faceProjection</b>([<i>faceProjection</i>]) set and read the corresponding options. Use <i>.faceFind(voronoi.find)</i> for faster results.
 
-<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) · [Examples](https://observablehq.com/@fil/cubic-projections)
+<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js), [Examples](https://observablehq.com/@fil/cubic-projections)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cubic.png" width="480" height="250">](https://observablehq.com/@fil/cubic-projections)
 
 The cubic projection.
 
-<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) · [Examples](https://observablehq.com/@fil/dodecahedral-projection)
+<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js), [Examples](https://observablehq.com/@fil/dodecahedral-projection)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/dodecahedral.png" width="480" height="250">](https://observablehq.com/@fil/dodecahedral-projection)
 
 The dodecahedral projection.
 
-<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) · [Examples](https://observablehq.com/@fil/icosahedral-projections)
+<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js), [Examples](https://observablehq.com/@fil/icosahedral-projections)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/icosahedral.png" width="480" height="250">](https://observablehq.com/@fil/icosahedral-projections)
 
 The icosahedral projection.
 
-<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) · [Examples](https://observablehq.com/@fil/airocean-projection)
+<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js), [Examples](https://observablehq.com/@fil/airocean-projection)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/airocean.png" width="480" height="250">](https://observablehq.com/@fil/airocean-projection)
 
 Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based on a very specific arrangement of the icosahedron which allows continuous continent shapes. Fuller’s triangle transformation, as formulated by Robert W. Gray (and implemented by Philippe Rivière), makes the projection almost equal-area.
 
-<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) · [Examples](https://observablehq.com/@d3/cahill-keyes)
+<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js), [Examples](https://observablehq.com/@d3/cahill-keyes)
 <br><a href="#geoCahillKeyesRaw" name="geoCahillKeyesRaw">#</a> d3.<b>geoCahillKeyes</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cahillKeyes.png" width="480" height="250">](http://www.genekeyes.com/)
 
 The Cahill-Keyes projection, designed by Gene Keyes (1975), is built on Bernard J. S. Cahill’s 1909 octant design. Implementation by Mary Jo Graça (2011), ported to D3 by Enrico Spinielli (2013).
 
-<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) · [Examples](https://observablehq.com/@fil/the-imago-projection)
+<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js), [Examples](https://observablehq.com/@fil/the-imago-projection)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/imago.png" width="480" height="250">](https://kunimune.home.blog/2017/11/23/the-secrets-of-the-authagraph-revealed/)
 
@@ -122,7 +122,7 @@ Exponent. Useful values include 0.59 (default, minimizes angular distortion of t
 
 Horizontal shift. Defaults to 1.16.
 
-<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) · [Examples](https://observablehq.com/@fil/lee-projection)
+<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js), [Examples](https://observablehq.com/@fil/lee-projection)
 <br><a href="#geoLeeRaw" name="geoLeeRaw">#</a> d3.<b>geoLeeRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/tetrahedralLee.png" width="480" height="250">](https://observablehq.com/@d3/lees-tetrahedral)
@@ -133,7 +133,7 @@ Lee’s tetrahedral conformal projection.
 
 Default aspect uses *projection*.rotate([30, 180]) and has the North Pole at the triangle’s center -- use *projection*.rotate([-30, 0]) for the [South aspect](https://observablehq.com/@fil/lee-projection).
 
-<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) · [Examples](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
+<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() · [Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js), [Examples](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
 <br><a href="#geoCoxRaw" name="geoCoxRaw">#</a> d3.<b>geoCoxRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cox.png" width="480" height="250">](https://visionscarto.net/cox-conformal-projection)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var projection = d3.geoEquirectangular()
 
 ## API Reference
 
-<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) [examples](https://observablehq.com/@mbostock/spherical-clipping)
+<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) · [examples](https://observablehq.com/@mbostock/spherical-clipping)]
 
 Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable for [_projection_.preclip](https://github.com/d3/d3-geo#preclip).
 
@@ -39,7 +39,7 @@ Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable fo
 Given a clipPolygon function, returns the GeoJSON polygon.
 
 
-<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) [examples](https://observablehq.com/@fil/spherical-intersection)
+<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) · [examples](https://observablehq.com/@fil/spherical-intersection)]
 
 
 Given two spherical arcs [point0, point1] and [point2, point3], returns their intersection, or undefined if there is none. See “[Spherical Intersection](https://observablehq.com/@fil/spherical-intersection)”.
@@ -50,7 +50,7 @@ Given two spherical arcs [point0, point1] and [point2, point3], returns their in
 d3-geo-polygon adds polygon clipping to the polyhedral projections from [d3-geo-projection](https://github.com/d3/d3-geo-projection). Thus, it supercedes the following symbols:
 
 
-<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) [examples](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
+<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) · [examples](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)]
 
 
 Defines a new polyhedral projection. The *tree* is a spanning tree of polygon face nodes; each *node* is assigned a *node*.transform matrix. The *face* function returns the appropriate *node* for a given *lambda* and *phi* in radians.
@@ -58,19 +58,19 @@ Defines a new polyhedral projection. The *tree* is a spanning tree of polygon fa
 <a href="#geoPolyhedral_tree" name="geoPolyhedral_tree">#</a> <i>polyhedral</i>.<b>tree</b>() returns the spanning tree of the polyhedron, from which one can infer the faces’ centers, polygons, shared edges etc.
 
 
-<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)
+<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)]
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralButterfly.png" width="480" height="250">](https://observablehq.com/@d3/polyhedral-gnomonic)
 
 The gnomonic butterfly projection.
 
-<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)
+<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)]
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralCollignon.png" width="480" height="250">](https://www.jasondavies.com/maps/collignon-butterfly/)
 
 The Collignon butterfly projection.
 
-<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)
+<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)]
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralWaterman.png" width="480" height="250">](https://www.jasondavies.com/maps/waterman-butterfly/)
 
@@ -79,47 +79,47 @@ A butterfly projection inspired by Steve Waterman’s design.
 
 New projections are introduced:
 
-<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)
+<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)]
 
 Returns a polyhedral projection based on the *polygons*, arranged in a tree according to the *parents* list. *polygons* are a GeoJSON FeatureCollection of geoVoronoi cells, which should indicate the corresponding sites (see [d3-geo-voronoi](https://github.com/Fil/d3-geo-voronoi)). An optional [*faceProjection*](#geoPolyhedral) is passed to d3.geoPolyhedral() -- note that the gnomonic projection on the polygons’ sites is the only faceProjection that works in the general case.
 
 The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>faceProjection</b>([<i>faceProjection</i>]) set and read the corresponding options. Use <i>.faceFind(voronoi.find)</i> for faster results.
 
-<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) [examples](https://observablehq.com/@fil/cubic-projections)
+<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) · [examples](https://observablehq.com/@fil/cubic-projections)]
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cubic.png" width="480" height="250">](https://observablehq.com/@fil/cubic-projections)
 
 The cubic projection.
 
-<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) [examples](https://observablehq.com/@fil/dodecahedral-projection)
+<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) · [examples](https://observablehq.com/@fil/dodecahedral-projection)]
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/dodecahedral.png" width="480" height="250">](https://observablehq.com/@fil/dodecahedral-projection)
 
 The dodecahedral projection.
 
-<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) [examples](https://observablehq.com/@fil/icosahedral-projections)
+<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) · [examples](https://observablehq.com/@fil/icosahedral-projections)]
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/icosahedral.png" width="480" height="250">](https://observablehq.com/@fil/icosahedral-projections)
 
 The icosahedral projection.
 
-<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) [examples](https://observablehq.com/@fil/airocean-projection)
+<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) · [examples](https://observablehq.com/@fil/airocean-projection)]
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/airocean.png" width="480" height="250">](https://observablehq.com/@fil/airocean-projection)
 
 Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based on a very specific arrangement of the icosahedron which allows continuous continent shapes. Fuller’s triangle transformation, as formulated by Robert W. Gray (and implemented by Philippe Rivière), makes the projection almost equal-area.
 
-<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) [examples](https://observablehq.com/@d3/cahill-keyes)
+<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) · [examples](https://observablehq.com/@d3/cahill-keyes)]
 <br><a href="#geoCahillKeyesRaw" name="geoCahillKeyesRaw">#</a> d3.<b>geoCahillKeyes</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cahillKeyes.png" width="480" height="250">](http://www.genekeyes.com/)
 
 The Cahill-Keyes projection, designed by Gene Keyes (1975), is built on Bernard J. S. Cahill’s 1909 octant design. Implementation by Mary Jo Graça (2011), ported to D3 by Enrico Spinielli (2013).
 
-<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) [examples](https://observablehq.com/@fil/the-imago-projection)
+<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) · [examples](https://observablehq.com/@fil/the-imago-projection)]
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/imago.png" width="480" height="250">](https://kunimune.home.blog/2017/11/23/the-secrets-of-the-authagraph-revealed/)
@@ -134,7 +134,7 @@ Exponent. Useful values include 0.59 (default, minimizes angular distortion of t
 
 Horizontal shift. Defaults to 1.16.
 
-<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) [examples](https://observablehq.com/@fil/lee-projection)
+<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) · [examples](https://observablehq.com/@fil/lee-projection)]
 <br><a href="#geoLeeRaw" name="geoLeeRaw">#</a> d3.<b>geoLeeRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/tetrahedralLee.png" width="480" height="250">](https://observablehq.com/@d3/lees-tetrahedral)
@@ -145,9 +145,10 @@ Lee’s tetrahedral conformal projection.
 
 Default aspect uses *projection*.rotate([30, 180]) and has the North Pole at the triangle’s center -- use *projection*.rotate([-30, 0]) for the [South aspect](https://observablehq.com/@fil/lee-projection).
 
-<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) [examples](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
+<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) · [examples](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)]
 <br><a href="#geoCoxRaw" name="geoCoxRaw">#</a> d3.<b>geoCoxRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cox.png" width="480" height="250">](https://visionscarto.net/cox-conformal-projection)
 
 The Cox conformal projection.
+

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var projection = d3.geoEquirectangular()
 
 ## API Reference
 
-<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) [[Examples]](https://observablehq.com/@mbostock/spherical-clipping)
+<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) [[Examples]](https://observablehq.com/@mbostock/spherical-clipping)</small>
 
 Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable for [_projection_.preclip](https://github.com/d3/d3-geo#preclip).
 
@@ -39,7 +39,7 @@ Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable fo
 Given a clipPolygon function, returns the GeoJSON polygon.
 
 
-<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) [[Examples]](https://observablehq.com/@fil/spherical-intersection)
+<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) [[Examples]](https://observablehq.com/@fil/spherical-intersection)</small>
 
 
 Given two spherical arcs [point0, point1] and [point2, point3], returns their intersection, or undefined if there is none. See “[Spherical Intersection](https://observablehq.com/@fil/spherical-intersection)”.
@@ -50,7 +50,7 @@ Given two spherical arcs [point0, point1] and [point2, point3], returns their in
 d3-geo-polygon adds polygon clipping to the polyhedral projections from [d3-geo-projection](https://github.com/d3/d3-geo-projection). Thus, it supercedes the following symbols:
 
 
-<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) [[Examples]](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
+<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) [[Examples]](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)</small>
 
 
 Defines a new polyhedral projection. The *tree* is a spanning tree of polygon face nodes; each *node* is assigned a *node*.transform matrix. The *face* function returns the appropriate *node* for a given *lambda* and *phi* in radians.
@@ -58,19 +58,19 @@ Defines a new polyhedral projection. The *tree* is a spanning tree of polygon fa
 <a href="#geoPolyhedral_tree" name="geoPolyhedral_tree">#</a> <i>polyhedral</i>.<b>tree</b>() returns the spanning tree of the polyhedron, from which one can infer the faces’ centers, polygons, shared edges etc.
 
 
-<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)
+<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)</small>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralButterfly.png" width="480" height="250">](https://observablehq.com/@d3/polyhedral-gnomonic)
 
 The gnomonic butterfly projection.
 
-<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)
+<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)</small>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralCollignon.png" width="480" height="250">](https://www.jasondavies.com/maps/collignon-butterfly/)
 
 The Collignon butterfly projection.
 
-<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)
+<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)</small>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralWaterman.png" width="480" height="250">](https://www.jasondavies.com/maps/waterman-butterfly/)
 
@@ -79,47 +79,47 @@ A butterfly projection inspired by Steve Waterman’s design.
 
 New projections are introduced:
 
-<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)
+<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)</small>
 
 Returns a polyhedral projection based on the *polygons*, arranged in a tree according to the *parents* list. *polygons* are a GeoJSON FeatureCollection of geoVoronoi cells, which should indicate the corresponding sites (see [d3-geo-voronoi](https://github.com/Fil/d3-geo-voronoi)). An optional [*faceProjection*](#geoPolyhedral) is passed to d3.geoPolyhedral() -- note that the gnomonic projection on the polygons’ sites is the only faceProjection that works in the general case.
 
 The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>faceProjection</b>([<i>faceProjection</i>]) set and read the corresponding options. Use <i>.faceFind(voronoi.find)</i> for faster results.
 
-<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) [[Examples]](https://observablehq.com/@fil/cubic-projections)
+<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) [[Examples]](https://observablehq.com/@fil/cubic-projections)</small>
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cubic.png" width="480" height="250">](https://observablehq.com/@fil/cubic-projections)
 
 The cubic projection.
 
-<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) [[Examples]](https://observablehq.com/@fil/dodecahedral-projection)
+<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) [[Examples]](https://observablehq.com/@fil/dodecahedral-projection)</small>
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/dodecahedral.png" width="480" height="250">](https://observablehq.com/@fil/dodecahedral-projection)
 
 The dodecahedral projection.
 
-<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) [[Examples]](https://observablehq.com/@fil/icosahedral-projections)
+<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) [[Examples]](https://observablehq.com/@fil/icosahedral-projections)</small>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/icosahedral.png" width="480" height="250">](https://observablehq.com/@fil/icosahedral-projections)
 
 The icosahedral projection.
 
-<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) [[Examples]](https://observablehq.com/@fil/airocean-projection)
+<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) [[Examples]](https://observablehq.com/@fil/airocean-projection)</small>
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/airocean.png" width="480" height="250">](https://observablehq.com/@fil/airocean-projection)
 
 Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based on a very specific arrangement of the icosahedron which allows continuous continent shapes. Fuller’s triangle transformation, as formulated by Robert W. Gray (and implemented by Philippe Rivière), makes the projection almost equal-area.
 
-<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) [[Examples]](https://observablehq.com/@d3/cahill-keyes)
+<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) [[Examples]](https://observablehq.com/@d3/cahill-keyes)</small>
 <br><a href="#geoCahillKeyesRaw" name="geoCahillKeyesRaw">#</a> d3.<b>geoCahillKeyes</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cahillKeyes.png" width="480" height="250">](http://www.genekeyes.com/)
 
 The Cahill-Keyes projection, designed by Gene Keyes (1975), is built on Bernard J. S. Cahill’s 1909 octant design. Implementation by Mary Jo Graça (2011), ported to D3 by Enrico Spinielli (2013).
 
-<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) [[Examples]](https://observablehq.com/@fil/the-imago-projection)
+<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) [[Examples]](https://observablehq.com/@fil/the-imago-projection)</small>
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/imago.png" width="480" height="250">](https://kunimune.home.blog/2017/11/23/the-secrets-of-the-authagraph-revealed/)
@@ -134,7 +134,7 @@ Exponent. Useful values include 0.59 (default, minimizes angular distortion of t
 
 Horizontal shift. Defaults to 1.16.
 
-<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) [[Examples]](https://observablehq.com/@fil/lee-projection)
+<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) [[Examples]](https://observablehq.com/@fil/lee-projection)</small>
 <br><a href="#geoLeeRaw" name="geoLeeRaw">#</a> d3.<b>geoLeeRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/tetrahedralLee.png" width="480" height="250">](https://observablehq.com/@d3/lees-tetrahedral)
@@ -145,7 +145,7 @@ Lee’s tetrahedral conformal projection.
 
 Default aspect uses *projection*.rotate([30, 180]) and has the North Pole at the triangle’s center -- use *projection*.rotate([-30, 0]) for the [South aspect](https://observablehq.com/@fil/lee-projection).
 
-<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) [[Examples]](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
+<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) [[Examples]](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)</small>
 <br><a href="#geoCoxRaw" name="geoCoxRaw">#</a> d3.<b>geoCoxRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cox.png" width="480" height="250">](https://visionscarto.net/cox-conformal-projection)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var projection = d3.geoEquirectangular()
 
 ## API Reference
 
-<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) [[examples]](https://observablehq.com/@mbostock/spherical-clipping)
+<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) [[Examples]](https://observablehq.com/@mbostock/spherical-clipping)
 
 Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable for [_projection_.preclip](https://github.com/d3/d3-geo#preclip).
 
@@ -39,7 +39,7 @@ Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable fo
 Given a clipPolygon function, returns the GeoJSON polygon.
 
 
-<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) [[examples]](https://observablehq.com/@fil/spherical-intersection)
+<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) [[Examples]](https://observablehq.com/@fil/spherical-intersection)
 
 
 Given two spherical arcs [point0, point1] and [point2, point3], returns their intersection, or undefined if there is none. See “[Spherical Intersection](https://observablehq.com/@fil/spherical-intersection)”.
@@ -50,7 +50,7 @@ Given two spherical arcs [point0, point1] and [point2, point3], returns their in
 d3-geo-polygon adds polygon clipping to the polyhedral projections from [d3-geo-projection](https://github.com/d3/d3-geo-projection). Thus, it supercedes the following symbols:
 
 
-<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) [[examples]](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
+<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) [[Examples]](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
 
 
 Defines a new polyhedral projection. The *tree* is a spanning tree of polygon face nodes; each *node* is assigned a *node*.transform matrix. The *face* function returns the appropriate *node* for a given *lambda* and *phi* in radians.
@@ -58,19 +58,19 @@ Defines a new polyhedral projection. The *tree* is a spanning tree of polygon fa
 <a href="#geoPolyhedral_tree" name="geoPolyhedral_tree">#</a> <i>polyhedral</i>.<b>tree</b>() returns the spanning tree of the polyhedron, from which one can infer the faces’ centers, polygons, shared edges etc.
 
 
-<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)
+<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralButterfly.png" width="480" height="250">](https://observablehq.com/@d3/polyhedral-gnomonic)
 
 The gnomonic butterfly projection.
 
-<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)
+<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralCollignon.png" width="480" height="250">](https://www.jasondavies.com/maps/collignon-butterfly/)
 
 The Collignon butterfly projection.
 
-<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)
+<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralWaterman.png" width="480" height="250">](https://www.jasondavies.com/maps/waterman-butterfly/)
 
@@ -79,47 +79,47 @@ A butterfly projection inspired by Steve Waterman’s design.
 
 New projections are introduced:
 
-<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)
+<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)
 
 Returns a polyhedral projection based on the *polygons*, arranged in a tree according to the *parents* list. *polygons* are a GeoJSON FeatureCollection of geoVoronoi cells, which should indicate the corresponding sites (see [d3-geo-voronoi](https://github.com/Fil/d3-geo-voronoi)). An optional [*faceProjection*](#geoPolyhedral) is passed to d3.geoPolyhedral() -- note that the gnomonic projection on the polygons’ sites is the only faceProjection that works in the general case.
 
 The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>faceProjection</b>([<i>faceProjection</i>]) set and read the corresponding options. Use <i>.faceFind(voronoi.find)</i> for faster results.
 
-<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) [[examples]](https://observablehq.com/@fil/cubic-projections)
+<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) [[Examples]](https://observablehq.com/@fil/cubic-projections)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cubic.png" width="480" height="250">](https://observablehq.com/@fil/cubic-projections)
 
 The cubic projection.
 
-<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) [[examples]](https://observablehq.com/@fil/dodecahedral-projection)
+<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) [[Examples]](https://observablehq.com/@fil/dodecahedral-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/dodecahedral.png" width="480" height="250">](https://observablehq.com/@fil/dodecahedral-projection)
 
 The dodecahedral projection.
 
-<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) [[examples]](https://observablehq.com/@fil/icosahedral-projections)
+<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) [[Examples]](https://observablehq.com/@fil/icosahedral-projections)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/icosahedral.png" width="480" height="250">](https://observablehq.com/@fil/icosahedral-projections)
 
 The icosahedral projection.
 
-<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) [[examples]](https://observablehq.com/@fil/airocean-projection)
+<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) [[Examples]](https://observablehq.com/@fil/airocean-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/airocean.png" width="480" height="250">](https://observablehq.com/@fil/airocean-projection)
 
 Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based on a very specific arrangement of the icosahedron which allows continuous continent shapes. Fuller’s triangle transformation, as formulated by Robert W. Gray (and implemented by Philippe Rivière), makes the projection almost equal-area.
 
-<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) [[examples]](https://observablehq.com/@d3/cahill-keyes)
+<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) [[Examples]](https://observablehq.com/@d3/cahill-keyes)
 <br><a href="#geoCahillKeyesRaw" name="geoCahillKeyesRaw">#</a> d3.<b>geoCahillKeyes</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cahillKeyes.png" width="480" height="250">](http://www.genekeyes.com/)
 
 The Cahill-Keyes projection, designed by Gene Keyes (1975), is built on Bernard J. S. Cahill’s 1909 octant design. Implementation by Mary Jo Graça (2011), ported to D3 by Enrico Spinielli (2013).
 
-<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) [[examples]](https://observablehq.com/@fil/the-imago-projection)
+<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) [[Examples]](https://observablehq.com/@fil/the-imago-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/imago.png" width="480" height="250">](https://kunimune.home.blog/2017/11/23/the-secrets-of-the-authagraph-revealed/)
@@ -134,7 +134,7 @@ Exponent. Useful values include 0.59 (default, minimizes angular distortion of t
 
 Horizontal shift. Defaults to 1.16.
 
-<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) [[examples]](https://observablehq.com/@fil/lee-projection)
+<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) [[Examples]](https://observablehq.com/@fil/lee-projection)
 <br><a href="#geoLeeRaw" name="geoLeeRaw">#</a> d3.<b>geoLeeRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/tetrahedralLee.png" width="480" height="250">](https://observablehq.com/@d3/lees-tetrahedral)
@@ -145,7 +145,7 @@ Lee’s tetrahedral conformal projection.
 
 Default aspect uses *projection*.rotate([30, 180]) and has the North Pole at the triangle’s center -- use *projection*.rotate([-30, 0]) for the [South aspect](https://observablehq.com/@fil/lee-projection).
 
-<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) [[examples]](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
+<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) [[Examples]](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
 <br><a href="#geoCoxRaw" name="geoCoxRaw">#</a> d3.<b>geoCoxRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cox.png" width="480" height="250">](https://visionscarto.net/cox-conformal-projection)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var projection = d3.geoEquirectangular()
 
 ## API Reference
 
-<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) · [examples](https://observablehq.com/@mbostock/spherical-clipping)]
+<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) [[examples]](https://observablehq.com/@mbostock/spherical-clipping)
 
 Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable for [_projection_.preclip](https://github.com/d3/d3-geo#preclip).
 
@@ -39,7 +39,7 @@ Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable fo
 Given a clipPolygon function, returns the GeoJSON polygon.
 
 
-<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) · [examples](https://observablehq.com/@fil/spherical-intersection)]
+<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) [[examples]](https://observablehq.com/@fil/spherical-intersection)
 
 
 Given two spherical arcs [point0, point1] and [point2, point3], returns their intersection, or undefined if there is none. See “[Spherical Intersection](https://observablehq.com/@fil/spherical-intersection)”.
@@ -50,7 +50,7 @@ Given two spherical arcs [point0, point1] and [point2, point3], returns their in
 d3-geo-polygon adds polygon clipping to the polyhedral projections from [d3-geo-projection](https://github.com/d3/d3-geo-projection). Thus, it supercedes the following symbols:
 
 
-<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) · [examples](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)]
+<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) [[examples]](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
 
 
 Defines a new polyhedral projection. The *tree* is a spanning tree of polygon face nodes; each *node* is assigned a *node*.transform matrix. The *face* function returns the appropriate *node* for a given *lambda* and *phi* in radians.
@@ -58,19 +58,19 @@ Defines a new polyhedral projection. The *tree* is a spanning tree of polygon fa
 <a href="#geoPolyhedral_tree" name="geoPolyhedral_tree">#</a> <i>polyhedral</i>.<b>tree</b>() returns the spanning tree of the polyhedron, from which one can infer the faces’ centers, polygons, shared edges etc.
 
 
-<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)]
+<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)]
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralButterfly.png" width="480" height="250">](https://observablehq.com/@d3/polyhedral-gnomonic)
 
 The gnomonic butterfly projection.
 
-<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)]
+<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)]
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralCollignon.png" width="480" height="250">](https://www.jasondavies.com/maps/collignon-butterfly/)
 
 The Collignon butterfly projection.
 
-<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)]
+<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)]
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralWaterman.png" width="480" height="250">](https://www.jasondavies.com/maps/waterman-butterfly/)
 
@@ -79,47 +79,47 @@ A butterfly projection inspired by Steve Waterman’s design.
 
 New projections are introduced:
 
-<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)]
+<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)]
 
 Returns a polyhedral projection based on the *polygons*, arranged in a tree according to the *parents* list. *polygons* are a GeoJSON FeatureCollection of geoVoronoi cells, which should indicate the corresponding sites (see [d3-geo-voronoi](https://github.com/Fil/d3-geo-voronoi)). An optional [*faceProjection*](#geoPolyhedral) is passed to d3.geoPolyhedral() -- note that the gnomonic projection on the polygons’ sites is the only faceProjection that works in the general case.
 
 The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>faceProjection</b>([<i>faceProjection</i>]) set and read the corresponding options. Use <i>.faceFind(voronoi.find)</i> for faster results.
 
-<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) · [examples](https://observablehq.com/@fil/cubic-projections)]
+<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) [[examples]](https://observablehq.com/@fil/cubic-projections)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cubic.png" width="480" height="250">](https://observablehq.com/@fil/cubic-projections)
 
 The cubic projection.
 
-<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) · [examples](https://observablehq.com/@fil/dodecahedral-projection)]
+<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) [[examples]](https://observablehq.com/@fil/dodecahedral-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/dodecahedral.png" width="480" height="250">](https://observablehq.com/@fil/dodecahedral-projection)
 
 The dodecahedral projection.
 
-<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) · [examples](https://observablehq.com/@fil/icosahedral-projections)]
+<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) [[examples]](https://observablehq.com/@fil/icosahedral-projections)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/icosahedral.png" width="480" height="250">](https://observablehq.com/@fil/icosahedral-projections)
 
 The icosahedral projection.
 
-<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) · [examples](https://observablehq.com/@fil/airocean-projection)]
+<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) [[examples]](https://observablehq.com/@fil/airocean-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/airocean.png" width="480" height="250">](https://observablehq.com/@fil/airocean-projection)
 
 Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based on a very specific arrangement of the icosahedron which allows continuous continent shapes. Fuller’s triangle transformation, as formulated by Robert W. Gray (and implemented by Philippe Rivière), makes the projection almost equal-area.
 
-<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) · [examples](https://observablehq.com/@d3/cahill-keyes)]
+<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) [[examples]](https://observablehq.com/@d3/cahill-keyes)
 <br><a href="#geoCahillKeyesRaw" name="geoCahillKeyesRaw">#</a> d3.<b>geoCahillKeyes</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cahillKeyes.png" width="480" height="250">](http://www.genekeyes.com/)
 
 The Cahill-Keyes projection, designed by Gene Keyes (1975), is built on Bernard J. S. Cahill’s 1909 octant design. Implementation by Mary Jo Graça (2011), ported to D3 by Enrico Spinielli (2013).
 
-<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) · [examples](https://observablehq.com/@fil/the-imago-projection)]
+<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) [[examples]](https://observablehq.com/@fil/the-imago-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/imago.png" width="480" height="250">](https://kunimune.home.blog/2017/11/23/the-secrets-of-the-authagraph-revealed/)
@@ -134,7 +134,7 @@ Exponent. Useful values include 0.59 (default, minimizes angular distortion of t
 
 Horizontal shift. Defaults to 1.16.
 
-<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) · [examples](https://observablehq.com/@fil/lee-projection)]
+<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) [[examples]](https://observablehq.com/@fil/lee-projection)
 <br><a href="#geoLeeRaw" name="geoLeeRaw">#</a> d3.<b>geoLeeRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/tetrahedralLee.png" width="480" height="250">](https://observablehq.com/@d3/lees-tetrahedral)
@@ -145,7 +145,7 @@ Lee’s tetrahedral conformal projection.
 
 Default aspect uses *projection*.rotate([30, 180]) and has the North Pole at the triangle’s center -- use *projection*.rotate([-30, 0]) for the [South aspect](https://observablehq.com/@fil/lee-projection).
 
-<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [[source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) · [examples](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)]
+<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) [[examples]](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
 <br><a href="#geoCoxRaw" name="geoCoxRaw">#</a> d3.<b>geoCoxRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cox.png" width="480" height="250">](https://visionscarto.net/cox-conformal-projection)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ var projection = d3.geoEquirectangular()
 
 ## API Reference
 
-<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) [[Examples]](https://observablehq.com/@mbostock/spherical-clipping)
+<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) · [Examples]](https://observablehq.com/@mbostock/spherical-clipping)
 
 Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable for [_projection_.preclip](https://github.com/d3/d3-geo#preclip).
 
@@ -39,7 +40,8 @@ Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable fo
 Given a clipPolygon function, returns the GeoJSON polygon.
 
 
-<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) [[Examples]](https://observablehq.com/@fil/spherical-intersection)
+<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) · [Examples]](https://observablehq.com/@fil/spherical-intersection)
 
 
 Given two spherical arcs [point0, point1] and [point2, point3], returns their intersection, or undefined if there is none. See “[Spherical Intersection](https://observablehq.com/@fil/spherical-intersection)”.
@@ -50,7 +52,8 @@ Given two spherical arcs [point0, point1] and [point2, point3], returns their in
 d3-geo-polygon adds polygon clipping to the polyhedral projections from [d3-geo-projection](https://github.com/d3/d3-geo-projection). Thus, it supercedes the following symbols:
 
 
-<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) [[Examples]](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
+<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>)
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) · [Examples]](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
 
 
 Defines a new polyhedral projection. The *tree* is a spanning tree of polygon face nodes; each *node* is assigned a *node*.transform matrix. The *face* function returns the appropriate *node* for a given *lambda* and *phi* in radians.
@@ -58,19 +61,22 @@ Defines a new polyhedral projection. The *tree* is a spanning tree of polygon fa
 <a href="#geoPolyhedral_tree" name="geoPolyhedral_tree">#</a> <i>polyhedral</i>.<b>tree</b>() returns the spanning tree of the polyhedron, from which one can infer the faces’ centers, polygons, shared edges etc.
 
 
-<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)
+<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>()
+<br>[[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)]
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralButterfly.png" width="480" height="250">](https://observablehq.com/@d3/polyhedral-gnomonic)
 
 The gnomonic butterfly projection.
 
-<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)
+<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>()
+<br>[[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)]
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralCollignon.png" width="480" height="250">](https://www.jasondavies.com/maps/collignon-butterfly/)
 
 The Collignon butterfly projection.
 
-<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)
+<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>()
+<br>[[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)]
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralWaterman.png" width="480" height="250">](https://www.jasondavies.com/maps/waterman-butterfly/)
 
@@ -79,47 +85,54 @@ A butterfly projection inspired by Steve Waterman’s design.
 
 New projections are introduced:
 
-<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)
+<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>])
+<br>[[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)]
 
 Returns a polyhedral projection based on the *polygons*, arranged in a tree according to the *parents* list. *polygons* are a GeoJSON FeatureCollection of geoVoronoi cells, which should indicate the corresponding sites (see [d3-geo-voronoi](https://github.com/Fil/d3-geo-voronoi)). An optional [*faceProjection*](#geoPolyhedral) is passed to d3.geoPolyhedral() -- note that the gnomonic projection on the polygons’ sites is the only faceProjection that works in the general case.
 
 The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>faceProjection</b>([<i>faceProjection</i>]) set and read the corresponding options. Use <i>.faceFind(voronoi.find)</i> for faster results.
 
-<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) [[Examples]](https://observablehq.com/@fil/cubic-projections)
+<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>()
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) · [Examples]](https://observablehq.com/@fil/cubic-projections)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cubic.png" width="480" height="250">](https://observablehq.com/@fil/cubic-projections)
 
 The cubic projection.
 
-<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) [[Examples]](https://observablehq.com/@fil/dodecahedral-projection)
+<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>()
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) · [Examples]](https://observablehq.com/@fil/dodecahedral-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/dodecahedral.png" width="480" height="250">](https://observablehq.com/@fil/dodecahedral-projection)
 
 The dodecahedral projection.
 
-<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) [[Examples]](https://observablehq.com/@fil/icosahedral-projections)
+<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>()
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) · [Examples]](https://observablehq.com/@fil/icosahedral-projections)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/icosahedral.png" width="480" height="250">](https://observablehq.com/@fil/icosahedral-projections)
 
 The icosahedral projection.
 
-<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) [[Examples]](https://observablehq.com/@fil/airocean-projection)
+<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>()
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) · [Examples]](https://observablehq.com/@fil/airocean-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/airocean.png" width="480" height="250">](https://observablehq.com/@fil/airocean-projection)
 
 Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based on a very specific arrangement of the icosahedron which allows continuous continent shapes. Fuller’s triangle transformation, as formulated by Robert W. Gray (and implemented by Philippe Rivière), makes the projection almost equal-area.
 
-<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) [[Examples]](https://observablehq.com/@d3/cahill-keyes)
+<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>()
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) · [Examples]](https://observablehq.com/@d3/cahill-keyes)
 <br><a href="#geoCahillKeyesRaw" name="geoCahillKeyesRaw">#</a> d3.<b>geoCahillKeyes</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cahillKeyes.png" width="480" height="250">](http://www.genekeyes.com/)
 
 The Cahill-Keyes projection, designed by Gene Keyes (1975), is built on Bernard J. S. Cahill’s 1909 octant design. Implementation by Mary Jo Graça (2011), ported to D3 by Enrico Spinielli (2013).
 
-<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) [[Examples]](https://observablehq.com/@fil/the-imago-projection)
+<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>()
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) · [Examples]](https://observablehq.com/@fil/the-imago-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/imago.png" width="480" height="250">](https://kunimune.home.blog/2017/11/23/the-secrets-of-the-authagraph-revealed/)
@@ -134,7 +147,8 @@ Exponent. Useful values include 0.59 (default, minimizes angular distortion of t
 
 Horizontal shift. Defaults to 1.16.
 
-<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) [[Examples]](https://observablehq.com/@fil/lee-projection)
+<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>()
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) · [Examples]](https://observablehq.com/@fil/lee-projection)
 <br><a href="#geoLeeRaw" name="geoLeeRaw">#</a> d3.<b>geoLeeRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/tetrahedralLee.png" width="480" height="250">](https://observablehq.com/@d3/lees-tetrahedral)
@@ -145,7 +159,8 @@ Lee’s tetrahedral conformal projection.
 
 Default aspect uses *projection*.rotate([30, 180]) and has the North Pole at the triangle’s center -- use *projection*.rotate([-30, 0]) for the [South aspect](https://observablehq.com/@fil/lee-projection).
 
-<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) [[Examples]](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
+<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>()
+<br>[Source](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) · [Examples]](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
 <br><a href="#geoCoxRaw" name="geoCoxRaw">#</a> d3.<b>geoCoxRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cox.png" width="480" height="250">](https://visionscarto.net/cox-conformal-projection)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var projection = d3.geoEquirectangular()
 
 ## API Reference
 
-<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) [[Examples]](https://observablehq.com/@mbostock/spherical-clipping)</small>
+<a name="geoClipPolygon" href="#geoClipPolygon">#</a> d3.<b>geoClipPolygon</b>(<i>polygon</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/clip/polygon.js) [[Examples]](https://observablehq.com/@mbostock/spherical-clipping)
 
 Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable for [_projection_.preclip](https://github.com/d3/d3-geo#preclip).
 
@@ -39,7 +39,7 @@ Given a GeoJSON *polygon* or *multipolygon*, returns a clip function suitable fo
 Given a clipPolygon function, returns the GeoJSON polygon.
 
 
-<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) [[Examples]](https://observablehq.com/@fil/spherical-intersection)</small>
+<a name="geoIntersectArc" href="#geoIntersectArc">#</a> d3.<b>geoIntersectArc</b>(<i>arcs</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/intersect.js) [[Examples]](https://observablehq.com/@fil/spherical-intersection)
 
 
 Given two spherical arcs [point0, point1] and [point2, point3], returns their intersection, or undefined if there is none. See “[Spherical Intersection](https://observablehq.com/@fil/spherical-intersection)”.
@@ -50,7 +50,7 @@ Given two spherical arcs [point0, point1] and [point2, point3], returns their in
 d3-geo-polygon adds polygon clipping to the polyhedral projections from [d3-geo-projection](https://github.com/d3/d3-geo-projection). Thus, it supercedes the following symbols:
 
 
-<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) [[Examples]](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)</small>
+<a href="#geoPolyhedral" name="geoPolyhedral">#</a> d3.<b>geoPolyhedral</b>(<i>tree</i>, <i>face</i>) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/index.js) [[Examples]](https://observablehq.com/@fil/polyhedral-projections-with-d3-geo-polygon)
 
 
 Defines a new polyhedral projection. The *tree* is a spanning tree of polygon face nodes; each *node* is assigned a *node*.transform matrix. The *face* function returns the appropriate *node* for a given *lambda* and *phi* in radians.
@@ -58,19 +58,19 @@ Defines a new polyhedral projection. The *tree* is a spanning tree of polygon fa
 <a href="#geoPolyhedral_tree" name="geoPolyhedral_tree">#</a> <i>polyhedral</i>.<b>tree</b>() returns the spanning tree of the polyhedron, from which one can infer the faces’ centers, polygons, shared edges etc.
 
 
-<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)</small>
+<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralButterfly.png" width="480" height="250">](https://observablehq.com/@d3/polyhedral-gnomonic)
 
 The gnomonic butterfly projection.
 
-<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)</small>
+<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralCollignon.png" width="480" height="250">](https://www.jasondavies.com/maps/collignon-butterfly/)
 
 The Collignon butterfly projection.
 
-<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)</small>
+<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralWaterman.png" width="480" height="250">](https://www.jasondavies.com/maps/waterman-butterfly/)
 
@@ -79,47 +79,47 @@ A butterfly projection inspired by Steve Waterman’s design.
 
 New projections are introduced:
 
-<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)</small>
+<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)
 
 Returns a polyhedral projection based on the *polygons*, arranged in a tree according to the *parents* list. *polygons* are a GeoJSON FeatureCollection of geoVoronoi cells, which should indicate the corresponding sites (see [d3-geo-voronoi](https://github.com/Fil/d3-geo-voronoi)). An optional [*faceProjection*](#geoPolyhedral) is passed to d3.geoPolyhedral() -- note that the gnomonic projection on the polygons’ sites is the only faceProjection that works in the general case.
 
 The .<b>parents</b>([<i>parents</i>]), .<b>polygons</b>([<i>polygons</i>]), .<b>faceProjection</b>([<i>faceProjection</i>]) set and read the corresponding options. Use <i>.faceFind(voronoi.find)</i> for faster results.
 
-<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) [[Examples]](https://observablehq.com/@fil/cubic-projections)</small>
+<a href="#geoCubic" name="geoCubic">#</a> d3.<b>geoCubic</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cubic.js) [[Examples]](https://observablehq.com/@fil/cubic-projections)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cubic.png" width="480" height="250">](https://observablehq.com/@fil/cubic-projections)
 
 The cubic projection.
 
-<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) [[Examples]](https://observablehq.com/@fil/dodecahedral-projection)</small>
+<a href="#geoDodecahedral" name="geoDodecahedral">#</a> d3.<b>geoDodecahedral</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/dodecahedral.js) [[Examples]](https://observablehq.com/@fil/dodecahedral-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/dodecahedral.png" width="480" height="250">](https://observablehq.com/@fil/dodecahedral-projection)
 
 The dodecahedral projection.
 
-<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) [[Examples]](https://observablehq.com/@fil/icosahedral-projections)</small>
+<a href="#geoIcosahedral" name="geoIcosahedral">#</a> d3.<b>geoIcosahedral</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/icosahedral.js) [[Examples]](https://observablehq.com/@fil/icosahedral-projections)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/icosahedral.png" width="480" height="250">](https://observablehq.com/@fil/icosahedral-projections)
 
 The icosahedral projection.
 
-<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) [[Examples]](https://observablehq.com/@fil/airocean-projection)</small>
+<a href="#geoAirocean" name="geoAirocean">#</a> d3.<b>geoAirocean</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/airocean.js) [[Examples]](https://observablehq.com/@fil/airocean-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/airocean.png" width="480" height="250">](https://observablehq.com/@fil/airocean-projection)
 
 Buckminster Fuller’s Airocean projection (also known as “Dymaxion”), based on a very specific arrangement of the icosahedron which allows continuous continent shapes. Fuller’s triangle transformation, as formulated by Robert W. Gray (and implemented by Philippe Rivière), makes the projection almost equal-area.
 
-<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) [[Examples]](https://observablehq.com/@d3/cahill-keyes)</small>
+<a href="#geoCahillKeyes" name="geoCahillKeyes">#</a> d3.<b>geoCahillKeyes</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cahillKeyes.js) [[Examples]](https://observablehq.com/@d3/cahill-keyes)
 <br><a href="#geoCahillKeyesRaw" name="geoCahillKeyesRaw">#</a> d3.<b>geoCahillKeyes</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cahillKeyes.png" width="480" height="250">](http://www.genekeyes.com/)
 
 The Cahill-Keyes projection, designed by Gene Keyes (1975), is built on Bernard J. S. Cahill’s 1909 octant design. Implementation by Mary Jo Graça (2011), ported to D3 by Enrico Spinielli (2013).
 
-<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) [[Examples]](https://observablehq.com/@fil/the-imago-projection)</small>
+<a href="#geoImago" name="geoImago">#</a> d3.<b>geoImago</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/imago.js) [[Examples]](https://observablehq.com/@fil/the-imago-projection)
 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/imago.png" width="480" height="250">](https://kunimune.home.blog/2017/11/23/the-secrets-of-the-authagraph-revealed/)
@@ -134,7 +134,7 @@ Exponent. Useful values include 0.59 (default, minimizes angular distortion of t
 
 Horizontal shift. Defaults to 1.16.
 
-<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) [[Examples]](https://observablehq.com/@fil/lee-projection)</small>
+<a href="#geoTetrahedralLee" name="geoTetrahedralLee">#</a> d3.<b>geoTetrahedralLee</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/tetrahedralLee.js) [[Examples]](https://observablehq.com/@fil/lee-projection)
 <br><a href="#geoLeeRaw" name="geoLeeRaw">#</a> d3.<b>geoLeeRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/tetrahedralLee.png" width="480" height="250">](https://observablehq.com/@d3/lees-tetrahedral)
@@ -145,7 +145,7 @@ Lee’s tetrahedral conformal projection.
 
 Default aspect uses *projection*.rotate([30, 180]) and has the North Pole at the triangle’s center -- use *projection*.rotate([-30, 0]) for the [South aspect](https://observablehq.com/@fil/lee-projection).
 
-<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() <small>[[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) [[Examples]](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)</small>
+<a href="#geoCox" name="geoCox">#</a> d3.<b>geoCox</b>() [[Source]](https://github.com/d3/d3-geo-polygon/blob/master/src/cox.js) [[Examples]](https://observablehq.com/@fil/cox-conformal-projection-in-a-triangle)
 <br><a href="#geoCoxRaw" name="geoCoxRaw">#</a> d3.<b>geoCoxRaw</b>
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/cox.png" width="480" height="250">](https://visionscarto.net/cox-conformal-projection)

--- a/README.md
+++ b/README.md
@@ -58,19 +58,19 @@ Defines a new polyhedral projection. The *tree* is a spanning tree of polygon fa
 <a href="#geoPolyhedral_tree" name="geoPolyhedral_tree">#</a> <i>polyhedral</i>.<b>tree</b>() returns the spanning tree of the polyhedron, from which one can infer the faces’ centers, polygons, shared edges etc.
 
 
-<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)]
+<a href="#geoPolyhedralButterfly" name="geoPolyhedralButterfly">#</a> d3.<b>geoPolyhedralButterfly</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/butterfly.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralButterfly.png" width="480" height="250">](https://observablehq.com/@d3/polyhedral-gnomonic)
 
 The gnomonic butterfly projection.
 
-<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)]
+<a href="#geoPolyhedralCollignon" name="geoPolyhedralCollignon">#</a> d3.<b>geoPolyhedralCollignon</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/collignon.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralCollignon.png" width="480" height="250">](https://www.jasondavies.com/maps/collignon-butterfly/)
 
 The Collignon butterfly projection.
 
-<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)]
+<a href="#geoPolyhedralWaterman" name="geoPolyhedralWaterman">#</a> d3.<b>geoPolyhedralWaterman</b>() [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/waterman.js)
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo-polygon/master/img/polyhedralWaterman.png" width="480" height="250">](https://www.jasondavies.com/maps/waterman-butterfly/)
 
@@ -79,7 +79,7 @@ A butterfly projection inspired by Steve Waterman’s design.
 
 New projections are introduced:
 
-<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)]
+<a href="#geoPolyhedralVoronoi" name="geoPolyhedralVoronoi">#</a> d3.<b>geoPolyhedralVoronoi</b>([<i>parents</i>], [<i>polygons</i>], [<i>faceProjection</i>], [<i>faceFind</i>]) [[source]](https://github.com/d3/d3-geo-polygon/blob/master/src/polyhedral/voronoi.js)
 
 Returns a polyhedral projection based on the *polygons*, arranged in a tree according to the *parents* list. *polygons* are a GeoJSON FeatureCollection of geoVoronoi cells, which should indicate the corresponding sites (see [d3-geo-voronoi](https://github.com/Fil/d3-geo-voronoi)). An optional [*faceProjection*](#geoPolyhedral) is passed to d3.geoPolyhedral() -- note that the gnomonic projection on the polygons’ sites is the only faceProjection that works in the general case.
 


### PR DESCRIPTION
I feel this is both more self-evident and easier to maintain.